### PR TITLE
Add initial PHPUnit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,11 @@ display_acf_qr_code('your_qr_code_field_name', null, [
     'class' => 'my-custom-class',
     'data-custom' => 'some-value'
 ]);
+
+## Running Tests
+
+To run the PHPUnit test suite, ensure PHP and PHPUnit are installed and then execute:
+
+```bash
+phpunit
 ```

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php">
+    <testsuites>
+        <testsuite name="Plugin Test Suite">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/GenerateQRCodeTest.php
+++ b/tests/GenerateQRCodeTest.php
@@ -1,0 +1,20 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class GenerateQRCodeTest extends TestCase
+{
+    public function test_generate_qrcode_image_returns_base64_img()
+    {
+        $field = new acf_field_qrcode();
+        $method = new ReflectionMethod(acf_field_qrcode::class, 'generate_qrcode_image');
+        $method->setAccessible(true);
+
+        $html = $method->invoke($field, 'https://example.com', [
+            'size' => 200,
+            'error_correction' => 'L',
+            'margin' => 4,
+        ]);
+
+        $this->assertStringContainsString('src="data:image/png;base64,', $html);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+// Basic stubs for WordPress functions used by the plugin
+if (!function_exists('esc_attr')) {
+    function esc_attr($text) {
+        return htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
+    }
+}
+if (!function_exists('esc_html')) {
+    function esc_html($text) {
+        return htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+// Load the plugin classes
+require_once dirname(__DIR__) . '/acf-qr-code-field/lib/phpqrcode/qrlib.php';
+require_once dirname(__DIR__) . '/acf-qr-code-field/fields/class-acf-field-qr-code.php';

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="bootstrap.php">
+    <testsuites>
+        <testsuite name="Plugin Test Suite">
+            <directory>./</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary
- add PHPUnit config and bootstrap with WordPress stubs
- test generate_qrcode_image outputs base64 img
- document how to run the tests

## Testing
- `phpunit --configuration phpunit.xml tests/GenerateQRCodeTest.php` *(fails: command not found)*